### PR TITLE
feat: Add support for isiOSAppOnVision method

### DIFF
--- a/ios/Classes/IsIosAppOnMacPlugin.swift
+++ b/ios/Classes/IsIosAppOnMacPlugin.swift
@@ -10,8 +10,10 @@ public class IsIosAppOnMacPlugin: NSObject, FlutterPlugin {
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
-    case "checkPlatform":
+    case "isiOSAppOnMac":
       result(isiOSAppOnMac())
+    case "isiOSAppOnVision":
+      result(isiOSAppOnVision())
     default:
       result(FlutterMethodNotImplemented)
     }
@@ -23,4 +25,11 @@ public class IsIosAppOnMacPlugin: NSObject, FlutterPlugin {
       }
       return false
     }
+
+  private func isiOSAppOnVision() -> Bool {
+    if #available(iOS 26.1, *) {
+      return ProcessInfo.processInfo.isiOSAppOnVision
+    }
+    return false
+  }
 }

--- a/ios/is_ios_app_on_mac.podspec
+++ b/ios/is_ios_app_on_mac.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'is_ios_app_on_mac'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/is_ios_app_on_mac.dart
+++ b/lib/is_ios_app_on_mac.dart
@@ -4,4 +4,8 @@ class IsIosAppOnMac {
   Future<bool> isiOSAppOnMac() {
     return IsIosAppOnMacPlatform.instance.isiOSAppOnMac();
   }
+
+  Future<bool> isiOSAppOnVision() {
+    return IsIosAppOnMacPlatform.instance.isiOSAppOnVision();
+  }
 }

--- a/lib/is_ios_app_on_mac_method_channel.dart
+++ b/lib/is_ios_app_on_mac_method_channel.dart
@@ -17,7 +17,20 @@ class MethodChannelIsIosAppOnMac extends IsIosAppOnMacPlatform {
       return false;
     }
     try {
-      final value = await methodChannel.invokeMethod<bool>('checkPlatform');
+      final value = await methodChannel.invokeMethod<bool>('isiOSAppOnMac');
+      return value ?? false;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> isiOSAppOnVision() async {
+    if (!Platform.isIOS) {
+      return false;
+    }
+    try {
+      final value = await methodChannel.invokeMethod<bool>('isiOSAppOnVision');
       return value ?? false;
     } catch (e) {
       return false;

--- a/lib/is_ios_app_on_mac_platform_interface.dart
+++ b/lib/is_ios_app_on_mac_platform_interface.dart
@@ -26,4 +26,8 @@ abstract class IsIosAppOnMacPlatform extends PlatformInterface {
   Future<bool> isiOSAppOnMac() {
     throw UnimplementedError('isiOSAppOnMac() has not been implemented.');
   }
+
+  Future<bool> isiOSAppOnVision() {
+    throw UnimplementedError('isiOSAppOnVision() has not been implemented.');
+  }
 }

--- a/test/is_ios_app_on_mac_test.dart
+++ b/test/is_ios_app_on_mac_test.dart
@@ -9,6 +9,9 @@ class MockIsIosAppOnMacPlatform
     implements IsIosAppOnMacPlatform {
   @override
   Future<bool> isiOSAppOnMac() => Future.value(false);
+
+  @override
+  Future<bool> isiOSAppOnVision() => Future.value(false);
 }
 
 void main() {
@@ -24,5 +27,13 @@ void main() {
     IsIosAppOnMacPlatform.instance = fakePlatform;
 
     expect(await isIosAppOnMacPlugin.isiOSAppOnMac(), false);
+  });
+
+  test('isiOSAppOnVision', () async {
+    IsIosAppOnMac isIosAppOnMacPlugin = IsIosAppOnMac();
+    MockIsIosAppOnMacPlatform fakePlatform = MockIsIosAppOnMacPlatform();
+    IsIosAppOnMacPlatform.instance = fakePlatform;
+
+    expect(await isIosAppOnMacPlugin.isiOSAppOnVision(), false);
   });
 }


### PR DESCRIPTION
Thanks for this plugin. It's just what I needed minus VisionOS support.

Added function to check if an iOS app is running on VisionOS: https://developer.apple.com/documentation/foundation/processinfo/isiosapponvision